### PR TITLE
Add usage hours documentation for hospital use

### DIFF
--- a/build/gettext/index.pot
+++ b/build/gettext/index.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uchino-it \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-07 01:13+0000\n"
+"POT-Creation-Date: 2025-12-07 01:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -24,18 +24,18 @@ msgstr ""
 msgid "manual of unino-it"
 msgstr ""
 
-#: ../../source/index.rst:26
+#: ../../source/index.rst:27
 msgid "Indices and tables"
 msgstr ""
 
-#: ../../source/index.rst:28
+#: ../../source/index.rst:29
 msgid ":ref:`genindex`"
 msgstr ""
 
-#: ../../source/index.rst:29
+#: ../../source/index.rst:30
 msgid ":ref:`modindex`"
 msgstr ""
 
-#: ../../source/index.rst:30
+#: ../../source/index.rst:31
 msgid ":ref:`search`"
 msgstr ""

--- a/build/gettext/telephone/index.pot
+++ b/build/gettext/telephone/index.pot
@@ -16,26 +16,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../../source/index.rst:9
-msgid "Contents:"
+#: ../../source/telephone/index.rst:2
+msgid "telephone"
 msgstr ""
 
-#: ../../source/index.rst:7
-msgid "manual of unino-it"
+#: ../../source/telephone/index.rst:6
+msgid "電話の出方"
 msgstr ""
 
-#: ../../source/index.rst:26
-msgid "Indices and tables"
+#: ../../source/telephone/index.rst:8
+msgid "電話がかかってくると、次のような画面が表示されます。連絡先に電話番号を登録している場合、矢印の場所に相手の名前が表示されます。"
 msgstr ""
 
-#: ../../source/index.rst:28
-msgid ":ref:`genindex`"
-msgstr ""
-
-#: ../../source/index.rst:29
-msgid ":ref:`modindex`"
-msgstr ""
-
-#: ../../source/index.rst:30
-msgid ":ref:`search`"
+#: ../../source/telephone/index.rst:13
+msgid "電話に出る場合は、「スライドで応答」と書かれた部分を指で触って、矢印のように右に動かしてください。"
 msgstr ""

--- a/build/gettext/usage-hours/index.pot
+++ b/build/gettext/usage-hours/index.pot
@@ -1,0 +1,93 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2022, Takahito Urai
+# This file is distributed under the same license as the uchino-it package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uchino-it \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-12-07 01:23+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: ../../source/usage-hours/index.rst:2
+msgid "usage-hours"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:6
+msgid "About Usage Hours"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:8
+msgid "This iPad is used in a hospital, so there are restrictions on usage hours."
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:12
+msgid "Daily Usage Limit"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:14
+msgid "You can use this iPad for up to **16 hours per day**."
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:18
+msgid "Hours When Usage is Not Allowed"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:20
+msgid "You cannot use this iPad from **10:00 PM (22:00)** to **6:00 AM (06:00)**."
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:22
+msgid "Please refrain from using the iPad during lights-out hours."
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:26
+msgid "Usage Hours Guide"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:28
+msgid "Available Hours"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:32
+msgid "Time"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:33
+msgid "Available"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:34
+msgid "Notes"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:35
+msgid "6:00 AM - 10:00 PM"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:36
+msgid "OK"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:37
+msgid "You can use up to 16 hours total during this period"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:38
+msgid "10:00 PM - 6:00 AM"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:39
+msgid "Not Available"
+msgstr ""
+
+#: ../../source/usage-hours/index.rst:40
+msgid "Lights-out / Sleeping hours"
+msgstr ""

--- a/build/gettext/youtube/index.pot
+++ b/build/gettext/youtube/index.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uchino-it \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-31 11:18+0900\n"
+"POT-Creation-Date: 2025-12-07 01:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -26,4 +26,16 @@ msgstr ""
 
 #: ../../source/youtube/index.rst:8
 msgid "赤いアイコンをタップしてください。"
+msgstr ""
+
+#: ../../source/youtube/index.rst:13
+msgid "虫眼鏡のアイコンをタップしてください。"
+msgstr ""
+
+#: ../../source/youtube/index.rst:18
+msgid "例えば大谷翔平の動画を見たい場合は、入力欄に「おおたにしょうへい」と入力します。 恐らく途中でおすすめのキーワードが補完されるので、その中から観たい動画をタップします。"
+msgstr ""
+
+#: ../../source/youtube/index.rst:24
+msgid "すると観たい動画が観れます。"
 msgstr ""

--- a/source/index.rst
+++ b/source/index.rst
@@ -11,6 +11,7 @@ manual of unino-it
    :maxdepth: 2
    :caption: Contents:
 
+   usage-hours/index
    telephone/index
    names/index
    trouble/index

--- a/source/locale/ja/LC_MESSAGES/telephone/index.po
+++ b/source/locale/ja/LC_MESSAGES/telephone/index.po
@@ -1,0 +1,37 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2022, Takahito Urai
+# This file is distributed under the same license as the uchino-it package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uchino-it \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-12-07 01:13+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: ../../source/telephone/index.rst:2
+msgid "telephone"
+msgstr ""
+
+#: ../../source/telephone/index.rst:6
+msgid "電話の出方"
+msgstr ""
+
+#: ../../source/telephone/index.rst:8
+msgid "電話がかかってくると、次のような画面が表示されます。連絡先に電話番号を登録している場合、矢印の場所に相手の名前が表示されます。"
+msgstr ""
+
+#: ../../source/telephone/index.rst:13
+msgid "電話に出る場合は、「スライドで応答」と書かれた部分を指で触って、矢印のように右に動かしてください。"
+msgstr ""
+

--- a/source/locale/ja/LC_MESSAGES/usage-hours/index.po
+++ b/source/locale/ja/LC_MESSAGES/usage-hours/index.po
@@ -1,0 +1,97 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) 2022, Takahito Urai
+# This file is distributed under the same license as the uchino-it package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2025.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: uchino-it \n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-12-07 01:23+0000\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language: ja\n"
+"Language-Team: ja <LL@li.org>\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.15.0\n"
+
+#: ../../source/usage-hours/index.rst:2
+msgid "usage-hours"
+msgstr "利用可能時間"
+
+#: ../../source/usage-hours/index.rst:6
+msgid "About Usage Hours"
+msgstr "利用可能時間について"
+
+#: ../../source/usage-hours/index.rst:8
+msgid "There are restrictions on usage hours at the hospital."
+msgstr "病院の利用時間には制限があります。"
+
+#: ../../source/usage-hours/index.rst:12
+msgid "Daily Usage Limit"
+msgstr "1日の利用時間"
+
+#: ../../source/usage-hours/index.rst:14
+msgid "You can use this iPad for up to **16 hours per day**."
+msgstr "1日に利用できる時間は **16時間まで** です。"
+
+#: ../../source/usage-hours/index.rst:18
+msgid "Hours When Usage is Not Allowed"
+msgstr "利用できない時間帯"
+
+#: ../../source/usage-hours/index.rst:20
+msgid "You cannot use this iPad from **10:00 PM (22:00)** to **6:00 AM (06:00)**."
+msgstr "夜の **22時（午後10時）** から朝の **6時** までは利用できません。"
+
+#: ../../source/usage-hours/index.rst:22
+msgid "Please refrain from using the iPad during lights-out hours."
+msgstr "この時間帯は消灯時間のため、iPadの使用はお控えください。"
+
+#: ../../source/usage-hours/index.rst:26
+msgid "Usage Hours Guide"
+msgstr "利用時間の目安"
+
+#: ../../source/usage-hours/index.rst:28
+msgid "Available Hours"
+msgstr "利用可能時間"
+
+#: ../../source/usage-hours/index.rst:32
+msgid "Time"
+msgstr "時間帯"
+
+#: ../../source/usage-hours/index.rst:33
+msgid "Available"
+msgstr "利用可否"
+
+#: ../../source/usage-hours/index.rst:34
+msgid "Notes"
+msgstr "備考"
+
+#: ../../source/usage-hours/index.rst:35
+msgid "6:00 AM - 10:00 PM"
+msgstr "6:00〜22:00"
+
+#: ../../source/usage-hours/index.rst:36
+msgid "OK"
+msgstr "○ 利用可能"
+
+#: ../../source/usage-hours/index.rst:37
+msgid "You can use up to 16 hours total during this period"
+msgstr "この間で合計16時間まで利用できます"
+
+#: ../../source/usage-hours/index.rst:38
+msgid "10:00 PM - 6:00 AM"
+msgstr "22:00〜6:00"
+
+#: ../../source/usage-hours/index.rst:39
+msgid "Not Available"
+msgstr "× 利用不可"
+
+#: ../../source/usage-hours/index.rst:40
+msgid "Lights-out / Sleeping hours"
+msgstr "消灯時間・就寝時間"
+

--- a/source/locale/ja/LC_MESSAGES/youtube/index.po
+++ b/source/locale/ja/LC_MESSAGES/youtube/index.po
@@ -8,14 +8,14 @@ msgid ""
 msgstr ""
 "Project-Id-Version: uchino-it \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-05-31 11:18+0900\n"
+"POT-Creation-Date: 2025-12-07 01:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.10.3\n"
+"Generated-By: Babel 2.15.0\n"
 
 #: ../../source/youtube/index.rst:2
 msgid "YouTube(動画)を観る"
@@ -27,5 +27,19 @@ msgstr ""
 
 #: ../../source/youtube/index.rst:8
 msgid "赤いアイコンをタップしてください。"
+msgstr ""
+
+#: ../../source/youtube/index.rst:13
+msgid "虫眼鏡のアイコンをタップしてください。"
+msgstr ""
+
+#: ../../source/youtube/index.rst:18
+msgid ""
+"例えば大谷翔平の動画を見たい場合は、入力欄に「おおたにしょうへい」と入力します。 "
+"恐らく途中でおすすめのキーワードが補完されるので、その中から観たい動画をタップします。"
+msgstr ""
+
+#: ../../source/youtube/index.rst:24
+msgid "すると観たい動画が観れます。"
 msgstr ""
 

--- a/source/usage-hours/index.rst
+++ b/source/usage-hours/index.rst
@@ -1,0 +1,40 @@
+usage-hours
+==========================================
+
+*************************
+About Usage Hours
+*************************
+
+There are restrictions on usage hours at the hospital.
+
+*************************
+Daily Usage Limit
+*************************
+
+You can use this iPad for up to **16 hours per day**.
+
+*************************
+Hours When Usage is Not Allowed
+*************************
+
+You cannot use this iPad from **10:00 PM (22:00)** to **6:00 AM (06:00)**.
+
+Please refrain from using the iPad during lights-out hours.
+
+*************************
+Usage Hours Guide
+*************************
+
+.. list-table:: Available Hours
+   :header-rows: 1
+   :widths: 20 20 60
+
+   * - Time
+     - Available
+     - Notes
+   * - 6:00 AM - 10:00 PM
+     - OK
+     - You can use up to 16 hours total during this period
+   * - 10:00 PM - 6:00 AM
+     - Not Available
+     - Lights-out / Sleeping hours


### PR DESCRIPTION
## Summary
- Add new "usage-hours" section explaining iPad usage time restrictions at hospital
- Daily limit: 16 hours
- No usage allowed between 22:00 and 06:00 (lights-out hours)
- Includes Japanese translation

## Test plan
- [ ] Build HTML documentation with `poetry run make html -e SPHINXOPTS='-D language="ja"'`
- [ ] Verify usage-hours section appears as first item in table of contents
- [ ] Confirm Japanese translations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)